### PR TITLE
Enable smooth rendering on iOS

### DIFF
--- a/CustomSplash/CustomSplash.Android/CustomSplash.Android.csproj
+++ b/CustomSplash/CustomSplash.Android/CustomSplash.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -29,6 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,6 +40,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/CustomSplash/CustomSplash.iOS/CustomSplash.iOS.csproj
+++ b/CustomSplash/CustomSplash.iOS/CustomSplash.iOS.csproj
@@ -92,6 +92,7 @@
   <ItemGroup>
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
+    <Compile Include="WorkaroundPageRenderer.cs" />
     <None Include="Entitlements.plist" />
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CustomSplash/CustomSplash.iOS/WorkaroundPageRenderer.cs
+++ b/CustomSplash/CustomSplash.iOS/WorkaroundPageRenderer.cs
@@ -1,0 +1,40 @@
+[assembly: Xamarin.Forms.ExportRenderer(typeof(Xamarin.Forms.Page), typeof(CustomSplash.iOS.WorkaroundPageRenderer))]
+
+namespace CustomSplash.iOS
+{
+    using System.Reflection;
+    using Xamarin.Forms;
+    using Xamarin.Forms.Platform.iOS;
+
+    // a workaround PageRenderer from https://kent-boogaart.com/blog/hacking-xamarin.forms-page.appearing-for-ios
+    public sealed class WorkaroundPageRenderer : PageRenderer
+    {
+        private static readonly FieldInfo AppearedField = typeof(PageRenderer).GetField("_appeared", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static readonly FieldInfo DisposedField = typeof(PageRenderer).GetField("_disposed", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        private IPageController PageController => this.Element as IPageController;
+
+        private bool Appeared
+        {
+            get => (bool)AppearedField.GetValue(this);
+            set => AppearedField.SetValue(this, value);
+        }
+
+        private bool Disposed
+        {
+            get => (bool)DisposedField.GetValue(this);
+            set => DisposedField.SetValue(this, value);
+        }
+
+        public override void ViewWillAppear(bool animated)
+        {
+            base.ViewWillAppear(animated);
+
+            if (Appeared || Disposed) return;
+
+            // by setting this to true, we also ensure that PageRenderer does not invoke SendAppearing a second time when ViewDidAppear fires
+            Appeared = true;
+            PageController.SendAppearing();
+        }
+    }
+}


### PR DESCRIPTION
Implements workaround suggested by Kent Boogart: https://kent-boogaart.com/blog/hacking-xamarin.forms-page.appearing-for-ios